### PR TITLE
Add new `datasets_as_hdf5` arg to save datasets as separate H5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ _version.py
 dandi_json
 *.csv
 nwb-cache
+test_output

--- a/README.md
+++ b/README.md
@@ -72,22 +72,35 @@ from dandi.dandiapi import DandiAPIClient
 from h5tojson import H5ToJson
 import os
 
-# Get the S3 URL of a particular NWB HDF5 file from Dandiset 000055
-dandiset_id = '000004'  # ephys dataset from the Svoboda Lab
-subject_id = 'sub-P11HMH'
-file_name = 'sub-P11HMH_ses-20061101_ecephys+image.nwb'
+# Get the S3 URL of a particular NWB HDF5 file from Dandiset 000049
+dandiset_id = '000049'  # ephys dataset from the Svoboda Lab
+subject_id = 'sub-661968859'
+file_name = 'sub-661968859_ses-681698752_behavior+ophys.nwb'
 with DandiAPIClient() as client:
     path = f"{subject_id}/{file_name}"
     asset = client.get_dandiset(dandiset_id).get_asset_by_path(path)
     s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
 
 # Create an output directory and set the output JSON path
-output_dir = f'{dandiset_id}/{subject_id}'
+output_dir = f'test_output/{dandiset_id}/{subject_id}'
 os.makedirs(output_dir, exist_ok=True)
-json_path = f'{output_dir}/sub-01_ses-7_behavior+ecephys.nwb.json'
+json_path = f'{output_dir}/sub-661968859_ses-681698752_behavior+ophys.nwb.json'
 
 # Create the H5ToJson translator object and run it
-translator = H5ToJson(s3_url, json_path, chunk_refs_file_path=None)
+translator = H5ToJson(s3_url, json_path)
+translator.translate()
+```
+
+## Run the translation and convert select datasets to an individual HDF5 file
+
+```python
+# Translate the same file, but save the DfOverF/data dataset as an individual HDF5 file
+translator = H5ToJson(
+    s3_url,
+    json_path,
+    datasets_as_hdf5=[
+        "/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data"
+    ])
 translator.translate()
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ translator = H5ToJson(
 translator.translate()
 ```
 
+This package supports taking an existing HDF5 file and translating it into:
+
+1. Only metadata as JSON (no datasets) (set `skip_all_dataset_data` == True)
+2. Metadata as JSON plus references to chunk locations for efficient streaming in a separate JSON (set `chunk_refs_file_path`)
+3. Metadata as JSON plus inlined datasets as readable values in the same JSON (configure `dataset_inline_max_bytes`, `object_dataset_inline_max_bytes`, `compound_dtype_dataset_inline_max_bytes`)
+4. Metadata as JSON plus select or all datasets stored as individual HDF5 files referenced by metadata JSON (set `datasets_as_hdf5`)
+
+
 ## What can we use these JSON for?
 
 Answering queries across many dandisets, e.g.:

--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ from h5tojson import H5ToJson
 import os
 
 # Get the S3 URL of a particular NWB HDF5 file from Dandiset 000049
-dandiset_id = '000049'  # ephys dataset from the Svoboda Lab
-subject_id = 'sub-661968859'
-file_name = 'sub-661968859_ses-681698752_behavior+ophys.nwb'
+dandiset_id = "000049"  # ephys dataset from the Svoboda Lab
+subject_id = "sub-661968859"
+file_name = "sub-661968859_ses-681698752_behavior+ophys.nwb"
 with DandiAPIClient() as client:
     path = f"{subject_id}/{file_name}"
     asset = client.get_dandiset(dandiset_id).get_asset_by_path(path)
     s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
 
 # Create an output directory and set the output JSON path
-output_dir = f'test_output/{dandiset_id}/{subject_id}'
+output_dir = f"test_output/{dandiset_id}/{subject_id}"
 os.makedirs(output_dir, exist_ok=True)
-json_path = f'{output_dir}/sub-661968859_ses-681698752_behavior+ophys.nwb.json'
+json_path = f"{output_dir}/sub-661968859_ses-681698752_behavior+ophys.nwb.json"
 
 # Create the H5ToJson translator object and run it
 translator = H5ToJson(s3_url, json_path)
@@ -96,11 +96,8 @@ translator.translate()
 ```python
 # Translate the same file, but save the DfOverF/data dataset as an individual HDF5 file
 translator = H5ToJson(
-    s3_url,
-    json_path,
-    datasets_as_hdf5=[
-        "/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data"
-    ])
+    s3_url, json_path, datasets_as_hdf5=["/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data"]
+)
 translator.translate()
 ```
 

--- a/h5tojson/conversions.py
+++ b/h5tojson/conversions.py
@@ -1,5 +1,9 @@
-from typing import Any, Dict, Optional
+"""Functions to convert HDF5 files to objects, dictionaries, and JSON files."""
+
+from typing import Any, Dict, Optional, Union
+
 from pydantic import BaseModel, Field
+
 from .h5tojson import H5ToJson, _remove_empty_dicts_in_dict
 from .models import H5ToJsonFile
 
@@ -14,6 +18,9 @@ class H5ToJsonOpts(BaseModel):
         2000, description="Max bytes for inline compound dtype dataset"
     )
     skip_all_dataset_data: bool = Field(False, description="Skip all data in datasets")
+    datasets_as_hdf5: Optional[Union[list[str], bool]] = Field(
+        None, description="Paths to datasets to be saved in individual hdf5 files"
+    )
     storage_options: Optional[dict] = Field(None, description="Storage options for the file")
 
 
@@ -27,6 +34,7 @@ def h5_to_object(hdf5_file_path: str, opts: Optional[H5ToJsonOpts] = H5ToJsonOpt
         object_dataset_inline_max_bytes=opts.object_dataset_inline_max_bytes,
         compound_dtype_dataset_inline_max_bytes=opts.compound_dtype_dataset_inline_max_bytes,
         skip_all_dataset_data=opts.skip_all_dataset_data,
+        datasets_as_hdf5=opts.datasets_as_hdf5,
         storage_options=opts.storage_options,
     )
     X.translate()
@@ -50,6 +58,7 @@ def h5_to_json_file(hdf5_file_path: str, json_file_path: str, opts: Optional[H5T
         object_dataset_inline_max_bytes=opts.object_dataset_inline_max_bytes,
         compound_dtype_dataset_inline_max_bytes=opts.compound_dtype_dataset_inline_max_bytes,
         skip_all_dataset_data=opts.skip_all_dataset_data,
+        datasets_as_hdf5=opts.datasets_as_hdf5,
         storage_options=opts.storage_options,
     )
     X.translate()

--- a/h5tojson/h5tojson.py
+++ b/h5tojson/h5tojson.py
@@ -201,6 +201,10 @@ class H5ToJson:
             List of string paths to datasets to be downloaded and saved as individual HDF5 files. If True, all datasets
             will be downloaded and saved. Each path must start with "/".
             False is equivalent to None. skip_all_dataset_data must be False if a value is provided here.
+            The individual HDF5 files have one dataset named "data" with the dataset, preserving all filters,
+            chunking settings, and attributes. The HDF5 files are placed in a new directory with the same name
+            as the output JSON file plus the path of the dataset within the HDF5 file. For example, a dataset at
+            `/DfOverF/data` will be written to `{output JSON file name without .json suffix}/DfOverF/data.h5`.
         storage_options : dict, optional
             Options to pass to fsspec when opening the HDF5 file. Default is None.
         """

--- a/h5tojson/h5tojson.py
+++ b/h5tojson/h5tojson.py
@@ -198,8 +198,8 @@ class H5ToJson:
         skip_all_dataset_data : bool, optional
             If True, then do not any data in datasets. Default is False.
         datasets_as_hdf5 : list or bool, optional
-            If not None, then string paths to datasets contained in this list are downloaded and saved as HDF5 files,
-            and the . Each path must start with "/". If True, then all datasets are downloaded saved as HDF5 files.
+            List of string paths to datasets to be downloaded and saved as individual HDF5 files. If True, all datasets
+            will be downloaded and saved. Each path must start with "/".
             False is equivalent to None. skip_all_dataset_data must be False if a value is provided here.
         storage_options : dict, optional
             Options to pass to fsspec when opening the HDF5 file. Default is None.
@@ -950,6 +950,7 @@ class H5ToJson:
 
 
 def _remove_empty_dicts_in_dict(x: dict):
+    """Remove empty dictionaries from a dictionary."""
     ret = {}
     for k, v in x.items():
         if isinstance(v, dict):
@@ -965,6 +966,7 @@ def _remove_empty_dicts_in_dict(x: dict):
 
 
 def _remove_empty_dicts_in_list(x: list):
+    """Remove empty dictionaries from a list."""
     ret = []
     for v in x:
         if isinstance(v, dict):

--- a/h5tojson/models.py
+++ b/h5tojson/models.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Optional, Union, Tuple
+"""Pydantic models for h5tojson."""
+
+from typing import Any, Dict, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field
 
@@ -8,6 +10,13 @@ class H5ToJsonDatasetRefs(BaseModel):
 
     file: str = Field(description="Path to the chunk refs file")
     prefix: str = Field(description="Prefix to use for the key")
+
+
+class H5ToJsonDatasetExternalFile(BaseModel):
+    """H5ToJsonDatasetExternalFile model"""
+
+    file: str = Field(description="Path to the external file")
+    key: str = Field(description="Key/path to the dataset within the external file")
 
 
 class H5ToJsonDataset(BaseModel):
@@ -22,6 +31,7 @@ class H5ToJsonDataset(BaseModel):
     compressor: Optional[str] = Field(None, description="Dataset compressor")
     fill_value: Optional[Union[str, int, float]] = Field(None, description="Dataset fill value")
     refs: Optional[H5ToJsonDatasetRefs] = Field(None, description="Dataset chunk refs")
+    external_file: Optional[H5ToJsonDatasetExternalFile] = Field(None, description="Dataset external file")
 
 
 class H5ToJsonSoftLink(BaseModel):
@@ -54,6 +64,9 @@ class H5ToJsonTranslationOptions(BaseModel):
     object_dataset_inline_max_bytes: int = Field(description="Max bytes for inline object dataset")
     compound_dtype_dataset_inline_max_bytes: int = Field(description="Max bytes for inline compound dtype dataset")
     skip_all_dataset_data: bool = Field(description="Skip all data in datasets")
+    datasets_as_hdf5: Optional[Union[list[str], bool]] = Field(
+        None, description="Paths to datasets to be saved in individual hdf5 files"
+    )
 
 
 class H5ToJsonFile(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ ignore_missing_imports = true
 fail-under = 95
 verbose = 1
 ignore-init-module = true
+ignore-nested-functions = true
 exclude = ["h5tojson/_version.py"]
 ignore-regex = ["set_up_test_file"]  # used in tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ line-length = 120
 [tool.ruff.per-file-ignores]
 # Ignore `F401` (imported but unused) in all `__init__.py` files, and in `path/to/file.py`.
 "__init__.py" = ["F401"]
+"scrape_dandi.py" = ["T201"]
 
 [tool.ruff.mccabe]
 max-complexity = 17

--- a/scrape_dandi.py
+++ b/scrape_dandi.py
@@ -185,7 +185,7 @@ def translate_dandiset_assets(
 
             s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
             start = time.perf_counter()
-            translator = H5ToJson(s3_url, json_path, None)
+            translator = H5ToJson(s3_url, json_path)
             translator.translate()
             end = time.perf_counter()
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,5 +1,7 @@
-# This code is a copy of the code in README.md.
-# It requires the internet to run because it streams an NWB file from DANDI.
+"""Test the example code in README.md.
+
+NOTE: This requires the internet because it streams an NWB file from DANDI.
+"""
 
 import os
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,32 @@
+# This code is a copy of the code in README.md.
+# It requires the internet to run because it streams an NWB file from DANDI.
+
+import os
+
+from dandi.dandiapi import DandiAPIClient
+
+from h5tojson import H5ToJson
+
+# Get the S3 URL of a particular NWB HDF5 file from Dandiset 000049
+dandiset_id = "000049"  # ephys dataset from the Svoboda Lab
+subject_id = "sub-661968859"
+file_name = "sub-661968859_ses-681698752_behavior+ophys.nwb"
+with DandiAPIClient() as client:
+    path = f"{subject_id}/{file_name}"
+    asset = client.get_dandiset(dandiset_id).get_asset_by_path(path)
+    s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
+
+# Create an output directory and set the output JSON path
+output_dir = f"test_output/{dandiset_id}/{subject_id}"
+os.makedirs(output_dir, exist_ok=True)
+json_path = f"{output_dir}/sub-661968859_ses-681698752_behavior+ophys.nwb.json"
+
+# Create the H5ToJson translator object and run it
+translator = H5ToJson(s3_url, json_path)
+translator.translate()
+
+# Translate the same file, but save the DfOverF/data dataset as an individual HDF5 file
+translator = H5ToJson(
+    s3_url, json_path, datasets_as_hdf5=["/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data"]
+)
+translator.translate()


### PR DESCRIPTION
Addresses #5

The new optional `datasets_as_hdf5` kwarg in `H5ToJson.__init__` is a list of string paths to datasets to be downloaded and saved as individual HDF5 files. It can also be True, which means all datasets will be downloaded and saved. 

The individual HDF5 files have one dataset named "data" with the dataset, preserving all filters, chunking settings, and attributes. The HDF5 files are placed in a new directory with the same name as the output JSON file plus the path of the dataset within the HDF5 file. For example, a dataset at
`/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data` will be written to 
`{output JSON file name without .json suffix}/processing/brain_observatory_pipeline/Fluorescence/DfOverF/data.h5`.

I also added:
- a `datasets_as_hdf5` field to the `H5ToJsonOpts` model
- a `datasets_as_hdf5` field to the `H5ToJsonTranslationOptions` model
- a new `H5ToJsonDatasetExternalFile` model
- a `external_file` field to the `H5ToJsonDataset` model. 

All new fields are optional.

This PR also:
- Update README example code and tests example in `tests/test_readme.py`
- Require that args after the first two required args in `H5ToJson.__init__` be named keyword args to prevent confusion over the meaning of lots of positional args.
- Add some missing docstrings and configure `interrogate` to ignore nested functions

Currently, this package supports taking an existing HDF5 file and translating it into:
1. Only metadata as JSON (no datasets) (set `skip_all_dataset_data` == True)
2. Metadata as JSON plus references to chunk locations for efficient streaming in a separate JSON (set `chunk_refs_file_path`)
3. Metadata as JSON plus inlined datasets as readable values in the same JSON (configure `dataset_inline_max_bytes`, `object_dataset_inline_max_bytes`, `compound_dtype_dataset_inline_max_bytes`)

This PR would add translating it into:

4. Metadata as JSON plus select or all datasets stored as individual HDF5 files referenced by metadata JSON (set `datasets_as_hdf5`)
